### PR TITLE
Fixes #558 : split environment variable at first occurence of =

### DIFF
--- a/frontend/src/components/applications/ApplicationDetailsComponents/AppContent.vue
+++ b/frontend/src/components/applications/ApplicationDetailsComponents/AppContent.vue
@@ -413,8 +413,13 @@ export default {
     splitEnv(data) {
       const env = [];
       for (let index = 0; index < data.length; index++) {
-        let _split_data = data[index].split("=");
-        env.push(_split_data);
+        let _split_pos = data[index].indexOf("=");
+        let _name = data[index].substr(
+          0,
+          _split_pos >= 0 ? _split_pos : data[index].length
+        );
+        let _value = _split_pos >= 0 ? data[index].substr(_split_pos + 1) : "";
+        env.push([_name, _value]);
       }
       return env;
     }


### PR DESCRIPTION
Fixes bug #558

    Run docker container outside Yacht: `docker run -t -d -p 127.0.0.1:9980:9980 -e "extra_params=--o:ssl.enable=false" --restart always collabora/code` (important part is to have env variable with = in the value, like here `--o:ssl.enable=false`)
    Go to Yacht
    Click on Application -> (your container name)
    See that in the environment variable info we can see only: `--o:ssl.enable`

Signed-off-by: Szymon Kłos <eszkadev@gmail.com>