### PR TITLE
Add docker to yacht for building images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN npm install
 COPY ./frontend/ .
 RUN npm run build
 
+# Download docker for building images from compose files
+# Not everything is needed so /usr/bin/docker can be copied
+# out later to keep the overall image size small
+RUN apk add docker
+
 # Setup Container and install Flask
 FROM lsiobase/alpine:3.12 as deploy-stage
 # MAINTANER Your Name "info@selfhosted.pro"
@@ -57,6 +62,9 @@ COPY root ./backend/alembic.ini /
 # Vue
 COPY --from=build-stage /app/dist /app
 COPY nginx.conf /etc/nginx/
+
+# Docker
+COPY --from=build-stage /usr/bin/docker /usr/bin/docker
 
 # Expose
 VOLUME /config


### PR DESCRIPTION
When a docker-compose project has a container with build requirements using the up button throws and error because `docker-compose` cannot find the docker command to trigger a native build.

To allow docker-compose files to contain build custom images I copy just the docker executable from the `build-stage` in the `deploy-stage` to keep the final image small. _I saw about 480MB final size._

This does fix the specific issue I ran into, but I have not done extensive testing to see if there are other docker functions that will break due to the missing dependencies.