### PR TITLE
Add docker-cli executable to deploy-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN npm install
 COPY ./frontend/ .
 RUN npm run build
 
+# Download docker for building images from compose files
+# Not everything is needed so /usr/bin/docker can be copied
+# out later to keep the overall image size small
+RUN apk add docker-cli
+
 # Setup Container and install Flask
 FROM lsiobase/alpine:3.16 as deploy-stage
 # MAINTANER Your Name "info@selfhosted.pro"
@@ -63,6 +68,9 @@ COPY root ./backend/alembic.ini /
 # Vue
 COPY --from=build-stage /app/dist /app
 COPY nginx.conf /etc/nginx/
+
+# Docker
+COPY --from=build-stage /usr/bin/docker /usr/bin/docker
 
 # Expose
 VOLUME /config


### PR DESCRIPTION
This is #571 but targeting nightly also only installs `docker-cli` instead of `docker` to decrease resources used during building